### PR TITLE
Fix duplicate new lines

### DIFF
--- a/lib/blocks/document.dart
+++ b/lib/blocks/document.dart
@@ -22,14 +22,13 @@ class Document extends Equatable {
 
   /// Returns the last [paragraph] into the document and validate before to avoid exceptions.
   Paragraph getLastSafe() {
-    if(paragraphs.isEmpty) paragraphs.add(Paragraph(lines: []));
+    if (paragraphs.isEmpty) paragraphs.add(Paragraph(lines: []));
     return paragraphs.last;
   }
 
   /// Returns the last [paragraph] into the document.
-  Paragraph getLast() {
-    if(paragraphs.isEmpty) paragraphs.add(Paragraph(lines: []));
-    return paragraphs.last;
+  Paragraph? getLast() {
+    return paragraphs.lastOrNull;
   }
 
   /// Update a last [paragraph] into the document validating to make more safe the operation.
@@ -61,20 +60,21 @@ class Document extends Equatable {
   }
 
   /// Ensures correct formatting of paragraphs in the document.
-  ///
-  /// TODO: Deprecated due to upcoming fixes needed.
   Document ensureCorrectFormat() {
     final List<Paragraph> newParagraphs = [];
     for (int index = 0; index < paragraphs.length; index++) {
       final Paragraph paragraph = paragraphs.elementAt(index);
       if (paragraph.lines.isNotEmpty) {
         final Line line = paragraph.lines.first;
-        if (line.data == '\n' && paragraph.blockAttributes != null && paragraph.lines.length > 1) {
-          newParagraphs.add(Paragraph(lines: [Line(data: '\n')], type: ParagraphType.inline));
+        if (line.data == '\n' && paragraph.lines.length > 1) {
+          newParagraphs.add(Paragraph(lines: [Line(data: '\n')], type: ParagraphType.block));
           paragraph.removeLine(0);
-          paragraph.setTypeSafe(ParagraphType.inline);
+          paragraph.setTypeSafe(paragraph.blockAttributes != null ? ParagraphType.block : ParagraphType.inline);
           newParagraphs.add(paragraph.clone);
         } else {
+          if (line.data == '\n' && paragraph.blockAttributes == null && paragraph.lines.length == 1) {
+            paragraph.setType(ParagraphType.block);
+          } 
           if (paragraph.blockAttributes != null) {
             paragraph.setTypeSafe(ParagraphType.block);
           } else {

--- a/test/flutter_quill_delta_easy_parser_test.dart
+++ b/test/flutter_quill_delta_easy_parser_test.dart
@@ -24,16 +24,22 @@ void main() {
     ]);
 
     final Document? parsedDocument = RichTextParser().parseDelta(delta);
-    expect(parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
+    expect(
+        parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
 
     for (int i = 0; i < expectedDocument.paragraphs.length; i++) {
-      expect(parsedDocument?.paragraphs[i].lines.length, expectedDocument.paragraphs[i].lines.length);
+      expect(parsedDocument?.paragraphs[i].lines.length,
+          expectedDocument.paragraphs[i].lines.length);
       for (int j = 0; j < expectedDocument.paragraphs[i].lines.length; j++) {
-        expect(parsedDocument?.paragraphs[i].lines[j].data, expectedDocument.paragraphs[i].lines[j].data);
-        expect(parsedDocument?.paragraphs[i].lines[j].attributes, expectedDocument.paragraphs[i].lines[j].attributes);
+        expect(parsedDocument?.paragraphs[i].lines[j].data,
+            expectedDocument.paragraphs[i].lines[j].data);
+        expect(parsedDocument?.paragraphs[i].lines[j].attributes,
+            expectedDocument.paragraphs[i].lines[j].attributes);
       }
-      expect(parsedDocument?.paragraphs[i].blockAttributes, expectedDocument.paragraphs[i].blockAttributes);
-      expect(parsedDocument?.paragraphs[i].type, expectedDocument.paragraphs[i].type);
+      expect(parsedDocument?.paragraphs[i].blockAttributes,
+          expectedDocument.paragraphs[i].blockAttributes);
+      expect(parsedDocument?.paragraphs[i].type,
+          expectedDocument.paragraphs[i].type);
     }
   });
 
@@ -57,25 +63,25 @@ void main() {
         ],
         type: ParagraphType.block,
       ),
-      Paragraph(
-        lines: [
-          Line(data: '\n'),
-        ],
-        type: ParagraphType.block,
-      ),
     ]);
 
     final Document? parsedDocument = RichTextParser().parseDelta(delta);
-    expect(parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
+    expect(
+        parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
 
     for (int i = 0; i < expectedDocument.paragraphs.length; i++) {
-      expect(parsedDocument?.paragraphs[i].lines.length, expectedDocument.paragraphs[i].lines.length);
+      expect(parsedDocument?.paragraphs[i].lines.length,
+          expectedDocument.paragraphs[i].lines.length);
       for (int j = 0; j < expectedDocument.paragraphs[i].lines.length; j++) {
-        expect(parsedDocument?.paragraphs[i].lines[j].data, expectedDocument.paragraphs[i].lines[j].data);
-        expect(parsedDocument?.paragraphs[i].lines[j].attributes, expectedDocument.paragraphs[i].lines[j].attributes);
+        expect(parsedDocument?.paragraphs[i].lines[j].data,
+            expectedDocument.paragraphs[i].lines[j].data);
+        expect(parsedDocument?.paragraphs[i].lines[j].attributes,
+            expectedDocument.paragraphs[i].lines[j].attributes);
       }
-      expect(parsedDocument?.paragraphs[i].blockAttributes, expectedDocument.paragraphs[i].blockAttributes);
-      expect(parsedDocument?.paragraphs[i].type, expectedDocument.paragraphs[i].type);
+      expect(parsedDocument?.paragraphs[i].blockAttributes,
+          expectedDocument.paragraphs[i].blockAttributes);
+      expect(parsedDocument?.paragraphs[i].type,
+          expectedDocument.paragraphs[i].type);
     }
   });
 
@@ -99,25 +105,25 @@ void main() {
         ],
         type: ParagraphType.block,
       ),
-      Paragraph(
-        lines: [
-          Line(data: '\n'),
-        ],
-        type: ParagraphType.block,
-      ),
     ]);
 
     final Document? parsedDocument = RichTextParser().parseDelta(delta);
-    expect(parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
+    expect(
+        parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
 
     for (int i = 0; i < expectedDocument.paragraphs.length; i++) {
-      expect(parsedDocument?.paragraphs[i].lines.length, expectedDocument.paragraphs[i].lines.length);
+      expect(parsedDocument?.paragraphs[i].lines.length,
+          expectedDocument.paragraphs[i].lines.length);
       for (int j = 0; j < expectedDocument.paragraphs[i].lines.length; j++) {
-        expect(parsedDocument?.paragraphs[i].lines[j].data, expectedDocument.paragraphs[i].lines[j].data);
-        expect(parsedDocument?.paragraphs[i].lines[j].attributes, expectedDocument.paragraphs[i].lines[j].attributes);
+        expect(parsedDocument?.paragraphs[i].lines[j].data,
+            expectedDocument.paragraphs[i].lines[j].data);
+        expect(parsedDocument?.paragraphs[i].lines[j].attributes,
+            expectedDocument.paragraphs[i].lines[j].attributes);
       }
-      expect(parsedDocument?.paragraphs[i].blockAttributes, expectedDocument.paragraphs[i].blockAttributes);
-      expect(parsedDocument?.paragraphs[i].type, expectedDocument.paragraphs[i].type);
+      expect(parsedDocument?.paragraphs[i].blockAttributes,
+          expectedDocument.paragraphs[i].blockAttributes);
+      expect(parsedDocument?.paragraphs[i].type,
+          expectedDocument.paragraphs[i].type);
     }
   });
 
@@ -153,7 +159,10 @@ void main() {
         blockAttributes: {"header": 1},
         type: ParagraphType.block,
       ),
-      Paragraph(lines: [Line(data: '\n')], blockAttributes: {"header": 1}, type: ParagraphType.block),
+      Paragraph(
+          lines: [Line(data: '\n')],
+          blockAttributes: {"header": 1},
+          type: ParagraphType.block),
       Paragraph(
         lines: [
           Line(data: 'This is a list item'),
@@ -174,6 +183,7 @@ void main() {
         ],
         type: ParagraphType.inline,
       ),
+      Paragraph(lines: [Line(data: '\n')], type: ParagraphType.block),
       Paragraph(
         lines: [
           Line(data: 'This is a '),
@@ -184,16 +194,22 @@ void main() {
       ),
     ]);
     final Document? parsedDocument = RichTextParser().parseDelta(delta);
-    expect(parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
+    expect(
+        parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
 
     for (int i = 0; i < expectedDocument.paragraphs.length; i++) {
-      expect(parsedDocument?.paragraphs[i].lines.length, expectedDocument.paragraphs[i].lines.length);
+      expect(parsedDocument?.paragraphs[i].lines.length,
+          expectedDocument.paragraphs[i].lines.length);
       for (int j = 0; j < expectedDocument.paragraphs[i].lines.length; j++) {
-        expect(parsedDocument?.paragraphs[i].lines[j].data, expectedDocument.paragraphs[i].lines[j].data);
-        expect(parsedDocument?.paragraphs[i].lines[j].attributes, expectedDocument.paragraphs[i].lines[j].attributes);
+        expect(parsedDocument?.paragraphs[i].lines[j].data,
+            expectedDocument.paragraphs[i].lines[j].data);
+        expect(parsedDocument?.paragraphs[i].lines[j].attributes,
+            expectedDocument.paragraphs[i].lines[j].attributes);
       }
-      expect(parsedDocument?.paragraphs[i].blockAttributes, expectedDocument.paragraphs[i].blockAttributes);
-      expect(parsedDocument?.paragraphs[i].type, expectedDocument.paragraphs[i].type);
+      expect(parsedDocument?.paragraphs[i].blockAttributes,
+          expectedDocument.paragraphs[i].blockAttributes);
+      expect(parsedDocument?.paragraphs[i].type,
+          expectedDocument.paragraphs[i].type);
     }
   });
 
@@ -215,16 +231,20 @@ void main() {
       Paragraph(lines: [Line(data: '\n')], type: ParagraphType.block),
     ]);
 
-    final Document? parsedDocument = RichTextParser().parseDelta(deltaWithNewlines);
-
-    expect(parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
+    final Document? parsedDocument =
+        RichTextParser().parseDelta(deltaWithNewlines);
+    expect(
+        parsedDocument?.paragraphs.length, expectedDocument.paragraphs.length);
 
     for (int i = 0; i < expectedDocument.paragraphs.length; i++) {
-      expect(parsedDocument?.paragraphs[i].lines.length, expectedDocument.paragraphs[i].lines.length);
+      expect(parsedDocument?.paragraphs[i].lines.length,
+          expectedDocument.paragraphs[i].lines.length);
       for (int j = 0; j < expectedDocument.paragraphs[i].lines.length; j++) {
-        expect(parsedDocument?.paragraphs[i].lines[j].data, expectedDocument.paragraphs[i].lines[j].data);
+        expect(parsedDocument?.paragraphs[i].lines[j].data,
+            expectedDocument.paragraphs[i].lines[j].data);
       }
-      expect(parsedDocument?.paragraphs[i].type, expectedDocument.paragraphs[i].type);
+      expect(parsedDocument?.paragraphs[i].type,
+          expectedDocument.paragraphs[i].type);
     }
   });
 }


### PR DESCRIPTION
Fixed `ensureCorrectFormat` from `Document` class since this just format `Paragraph` with `blockAttributes`. This issue affects some `Paragraph` that contains lines with Text and new lines, that should be on separate `Paragraphs`. 

Fixed `clone` method from `Paragraph` class that return a empty `blockAttributes`.