### PR TITLE
Fix: issue where mergers does not works as expected

### DIFF
--- a/lib/easy_parser/block_merger_builder.dart
+++ b/lib/easy_parser/block_merger_builder.dart
@@ -15,6 +15,22 @@ class BlockMergerBuilder extends MergerBuilder {
       final Paragraph curParagraph = paragraphs.elementAt(i);
       final Paragraph? nextParagraph = paragraphs.elementAtOrNull(i + 1);
       if (indexsIgnore.contains(i)) {
+        if (nextParagraph != null) {
+          if (canMergeBothParagraphs(
+              paragraph: curParagraph, nextParagraph: nextParagraph)) {
+            final Paragraph lastParagraph = result.last;
+            final Paragraph paragraphResult = Paragraph(
+              lines: <Line>[
+                ...lastParagraph.lines,
+                ...nextParagraph.lines,
+              ],
+              blockAttributes: curParagraph.blockAttributes,
+              type: curParagraph.type,
+            );
+            result[result.length - 1] = paragraphResult;
+            indexsIgnore.add(i + 1);
+          }
+        }
         continue;
       }
       // check if the current iteration is the last

--- a/lib/easy_parser/common_merger_builder.dart
+++ b/lib/easy_parser/common_merger_builder.dart
@@ -18,6 +18,22 @@ class CommonMergerBuilder extends MergerBuilder {
       final Paragraph curParagraph = paragraphs.elementAt(i);
       final Paragraph? nextParagraph = paragraphs.elementAtOrNull(i + 1);
       if (indexsIgnore.contains(i)) {
+        if (nextParagraph != null) {
+          if (canMergeBothParagraphs(
+              paragraph: curParagraph, nextParagraph: nextParagraph)) {
+            final Paragraph lastParagraph = result.last;
+            final Paragraph paragraphResult = Paragraph(
+              lines: <Line>[
+                ...lastParagraph.lines,
+                ...nextParagraph.lines,
+              ],
+              blockAttributes: curParagraph.blockAttributes,
+              type: curParagraph.type,
+            );
+            result[result.length - 1] = paragraphResult;
+            indexsIgnore.add(i + 1);
+          }
+        }
         continue;
       }
       // check if the current iteration is the last

--- a/test/flutter_quill_delta_easy_parser_test.dart
+++ b/test/flutter_quill_delta_easy_parser_test.dart
@@ -135,70 +135,27 @@ void main() {
     _execExpects(parsedDocument, expectedDocument);
   });
 
-  test('Should convert Delta with various attributes', () {
+  test(
+      'Should merge different paragraphs with similar attributes into a same one',
+      () {
     final Delta delta = Delta()
-      ..insert('This is ')
-      ..insert('bold', {'bold': true})
-      ..insert(' and ')
-      ..insert('italic', {'italic': true})
-      ..insert(' text with ')
-      ..insert('custom color', {'color': '#FF0000'})
-      ..insert('\n\n', {'header': 1})
-      ..insert('This is a list item')
-      ..insert('\n', {'list': 'ordered'})
-      ..insert('Another list item')
-      ..insert('\n', {'list': 'ordered'})
-      ..insert('Third list item')
-      ..insert('\n')
-      ..insert('This is a ')
-      ..insert('link', {'link': 'https://example.com'})
-      ..insert(' to a website')
+      ..insert('void main() {')
+      ..insert('\n', {'code-block': true})
+      ..insert('  print("hello world!");')
+      ..insert('\n', {'code-block': true})
+      ..insert('}')
+      ..insert('\n', {'code-block': true})
       ..insert('\n');
 
     final Document expectedDocument = Document(paragraphs: [
       Paragraph.sealed(
         lines: [
-          Line(
-            fragments: [
-              TextFragment(data: 'This is '),
-              TextFragment(data: 'bold', attributes: {'bold': true}),
-              TextFragment(data: ' and '),
-              TextFragment(data: 'italic', attributes: {'italic': true}),
-              TextFragment(data: ' text with '),
-              TextFragment(
-                  data: 'custom color', attributes: {'color': '#FF0000'}),
-            ],
-          ),
+          Line.fromData(data: 'void main() {'),
+          Line.fromData(data: '  print("hello world!");'),
+          Line.fromData(data: '}'),
         ],
-        blockAttributes: {"header": 1},
+        blockAttributes: {"code-block": true},
         type: ParagraphType.block,
-      ),
-      Paragraph(
-        lines: <Line>[Line.newLine()],
-        blockAttributes: {"header": 1},
-        type: ParagraphType.lineBreak,
-      ),
-      Paragraph(
-        lines: [
-          Line.fromData(data: 'This is a list item'),
-          Line.fromData(data: 'Another list item'),
-        ],
-        blockAttributes: {'list': 'ordered'},
-        type: ParagraphType.block,
-      ),
-      Paragraph(
-        lines: [
-          Line.fromData(data: 'Third list item'),
-          Line(
-            fragments: [
-              TextFragment(data: 'This is a '),
-              TextFragment(
-                  data: 'link', attributes: {'link': 'https://example.com'}),
-              TextFragment(data: ' to a website'),
-            ],
-          ),
-        ],
-        type: ParagraphType.inline,
       ),
       Paragraph.newLine(),
     ]);

--- a/test/flutter_quill_delta_easy_parser_test.dart
+++ b/test/flutter_quill_delta_easy_parser_test.dart
@@ -135,6 +135,77 @@ void main() {
     _execExpects(parsedDocument, expectedDocument);
   });
 
+  test('Should convert Delta with various attributes', () {
+    final Delta delta = Delta()
+      ..insert('This is ')
+      ..insert('bold', {'bold': true})
+      ..insert(' and ')
+      ..insert('italic', {'italic': true})
+      ..insert(' text with ')
+      ..insert('custom color', {'color': '#FF0000'})
+      ..insert('\n\n', {'header': 1})
+      ..insert('This is a list item')
+      ..insert('\n', {'list': 'ordered'})
+      ..insert('Another list item')
+      ..insert('\n', {'list': 'ordered'})
+      ..insert('Third list item')
+      ..insert('\n')
+      ..insert('This is a ')
+      ..insert('link', {'link': 'https://example.com'})
+      ..insert(' to a website')
+      ..insert('\n');
+
+    final Document expectedDocument = Document(paragraphs: [
+      Paragraph.sealed(
+        lines: [
+          Line(
+            fragments: [
+              TextFragment(data: 'This is '),
+              TextFragment(data: 'bold', attributes: {'bold': true}),
+              TextFragment(data: ' and '),
+              TextFragment(data: 'italic', attributes: {'italic': true}),
+              TextFragment(data: ' text with '),
+              TextFragment(
+                  data: 'custom color', attributes: {'color': '#FF0000'}),
+            ],
+          ),
+        ],
+        blockAttributes: {"header": 1},
+        type: ParagraphType.block,
+      ),
+      Paragraph(
+        lines: <Line>[Line.newLine()],
+        blockAttributes: {"header": 1},
+        type: ParagraphType.lineBreak,
+      ),
+      Paragraph(
+        lines: [
+          Line.fromData(data: 'This is a list item'),
+          Line.fromData(data: 'Another list item'),
+        ],
+        blockAttributes: {'list': 'ordered'},
+        type: ParagraphType.block,
+      ),
+      Paragraph(
+        lines: [
+          Line.fromData(data: 'Third list item'),
+          Line(
+            fragments: [
+              TextFragment(data: 'This is a '),
+              TextFragment(
+                  data: 'link', attributes: {'link': 'https://example.com'}),
+              TextFragment(data: ' to a website'),
+            ],
+          ),
+        ],
+        type: ParagraphType.inline,
+      ),
+      Paragraph.newLine(),
+    ]);
+    final Document? parsedDocument = DocumentParser().parseDelta(delta: delta);
+    _execExpects(parsedDocument, expectedDocument);
+  });
+
   test(
       'Should merge different paragraphs with similar attributes into a same one',
       () {


### PR DESCRIPTION
## Description.

Fixed an issue where the most common `MergerBuilder` does not work well when it finds multiple paragraphs in a row that share the same attributes.

## Type of change

- [x] 🛠️ Bug fix: Resolves an issue without altering current behavior.
- [ ]  🗑️ Chore: Routine tasks, or maintenance.
- [ ] ❌ Breaking: Alters existing functionality and requires updates.
- [x] 🧪 Tests: New or modified tests
- [ ] 📝 Documentation: Updates or additions to documentation.