### PR TITLE
Feat: added ability to set a custom id for paragraphs and lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Feat: provide your own custom ids
+
 ## 1.1.5
 
 * Fix: "cannot insert line when paragraph is sealed" exception when will insert a new line after a embed.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ class Paragraph {
     required this.lines,
     required this.type,
     this.blockAttributes,
+    String? id,
   });
 }
 ```
@@ -197,6 +198,7 @@ class Line {
 
   Line({
     required List<TextFragment> fragments,
+    String? id,
   });
 
   // General methods
@@ -211,11 +213,11 @@ This is useful when we have a **list**, **code-block** or **blockquote**, becaus
 
 You can see now it, like this plain text diagram representation:
 ```
---------------Paragraph------------------
-| 1. This is a ordered list item        |
-| 2. This is another ordered list item  |
-| 3. Just a different ordered list item |
------------------------------------------
+┌─────────────Paragraph─────────────────┐
+│ 1. This is a ordered list item        │
+│ 2. This is another ordered list item  │
+│ 3. Just a different ordered list item │
+└───────────────────────────────────────┘
 ```
 
 Its similar to create a `Paragraph` like (just when `BlockMergerBuilder` or `CommonMergerBuilder` is being used):

--- a/lib/blocks/document.dart
+++ b/lib/blocks/document.dart
@@ -129,7 +129,9 @@ class Document {
   /// Returns a string representation of the document.
   @override
   String toString() {
-    return 'Paragraphs: ${paragraphs.map((paragraph) => paragraph.toString()).toList().toString()}';
+    return 'Paragraphs: ${paragraphs.map<String>((Paragraph paragraph) {
+          return paragraph.toString();
+        }).toList().toString()}';
   }
 
   /// Returns a version of the string that can be readed more easily.
@@ -161,7 +163,7 @@ class Document {
   @override
   bool operator ==(covariant Document other) {
     if (identical(this, other)) return true;
-    return ListEquality().equals(paragraphs, other.paragraphs);
+    return ListEquality<Paragraph>().equals(paragraphs, other.paragraphs);
   }
 
   @override

--- a/lib/blocks/line.dart
+++ b/lib/blocks/line.dart
@@ -28,17 +28,21 @@ class Line {
 
   Line({
     required List<TextFragment> fragments,
+    String? id,
   })  : _fragments = List.from(fragments),
+        id = id == null || id.trim().isEmpty ? nanoid(8) : id,
         _sealed = fragments.isEmpty
             ? false
             : fragments.isNotEmpty && fragments.length == 1
                 ? fragments.first.data == '\n' ||
                     fragments.first.data is Map<String, dynamic>
-                : false,
-        id = nanoid(10);
+                : false;
 
-  Line.fromData({required Object data, Map<String, dynamic>? attributes})
-      : _fragments = List.from(
+  Line.fromData({
+    required Object data,
+    String? id,
+    Map<String, dynamic>? attributes,
+  })  : _fragments = List.from(
           [
             TextFragment(
               data: data,
@@ -46,10 +50,10 @@ class Line {
             )
           ],
         ),
-        _sealed = data == '\n' || data is Map ? true : false,
-        id = nanoid(10);
+        id = id == null || id.trim().isEmpty ? nanoid(8) : id,
+        _sealed = data == '\n' || data is Map ? true : false;
 
-  Line.newLine()
+  Line.newLine({String? id})
       : _fragments = List.from(
           [
             TextFragment(
@@ -58,12 +62,14 @@ class Line {
           ],
         ),
         _sealed = true,
-        id = nanoid(10);
+        id = id == null || id.trim().isEmpty ? nanoid(8) : id;
 
+  /// Set a sealed state, where we can't do any type of modification to this Line instance
   void seal() {
     _sealed = true;
   }
 
+  /// Removed the sealed state, to allow modification to this Line instance
   void unseal() {
     _sealed = false;
   }
@@ -163,8 +169,20 @@ class Line {
     add();
   }
 
-  /// Creates a deep copy of the current [Line] instance.
+  /// Creates a copy of the current [Line] instance.
   Line get clone => Line(fragments: <TextFragment>[..._fragments]);
+
+  /// Creates a deep copy of the current [Line] instance.
+  Line get deepClone {
+    return Line(
+      id: id,
+      fragments: _fragments
+          .map<TextFragment>(
+            (TextFragment e) => e.clone,
+          )
+          .toList(),
+    );
+  }
 
   List<TextFragment> get fragments =>
       List<TextFragment>.unmodifiable(_fragments);
@@ -210,13 +228,21 @@ class Line {
     return '${indent}Line: <Sealed value:$_sealed> [\n$rawFragments${'$indent  '}]';
   }
 
-  TextFragment elementAt(int index) => _fragments.elementAt(index);
-  TextFragment? elementAtOrNull(int index) => _fragments.elementAtOrNull(index);
+  TextFragment elementAt(int index) {
+    return _fragments.elementAt(index);
+  }
 
-  TextFragment operator [](int index) => _fragments[index];
+  TextFragment? elementAtOrNull(int index) {
+    return _fragments.elementAtOrNull(index);
+  }
 
-  void operator []=(int index, TextFragment fragment) =>
-      _fragments[index] = fragment;
+  TextFragment operator [](int index) {
+    return _fragments[index];
+  }
+
+  void operator []=(int index, TextFragment fragment) {
+    _fragments[index] = fragment;
+  }
 
   @override
   bool operator ==(covariant Line other) {

--- a/lib/blocks/paragraph.dart
+++ b/lib/blocks/paragraph.dart
@@ -59,8 +59,9 @@ class Paragraph {
     required List<Line> lines,
     required this.type,
     this.blockAttributes,
+    String? id,
   })  : _lines = List<Line>.from(lines),
-        id = nanoid(8),
+        id = id == null || id.trim().isEmpty ? nanoid(8) : id,
         _sealed = type == ParagraphType.block
             ? true
             : lines.isNotEmpty && lines.length == 1 && lines.first.isNotEmpty
@@ -74,12 +75,25 @@ class Paragraph {
     required List<Line> lines,
     required this.type,
     this.blockAttributes,
+    String? id,
   })  : _lines = List<Line>.from(lines),
-        id = nanoid(8),
+        id = id == null || id.trim().isEmpty ? nanoid(8) : id,
         _sealed = true;
 
-  factory Paragraph.withLine() {
+  @visibleForTesting
+  factory Paragraph.fragment(TextFragment frag, {String? id}) {
+    return Paragraph.sealed(
+      id: id,
+      lines: <Line>[
+        Line(fragments: <TextFragment>[frag.clone])
+      ],
+      type: ParagraphType.inline,
+    );
+  }
+
+  factory Paragraph.withLine({String? id}) {
     return Paragraph(
+      id: id,
       lines: <Line>[
         Line(
           fragments: [],
@@ -89,15 +103,20 @@ class Paragraph {
     );
   }
 
-  factory Paragraph.base() {
+  factory Paragraph.base({String? id}) {
     return Paragraph(
+      id: id,
       lines: <Line>[],
       type: ParagraphType.inline,
     );
   }
 
-  factory Paragraph.newLine({Map<String, dynamic>? blockAttributes}) {
+  factory Paragraph.newLine({
+    Map<String, dynamic>? blockAttributes,
+    String? id,
+  }) {
     return Paragraph(
+      id: id,
       lines: <Line>[
         Line.newLine(),
       ],
@@ -108,11 +127,14 @@ class Paragraph {
 
   /// Constructs a [Paragraph] instance from a Object embed.
   /// [operation] is the Quill Delta operation representing the embed.
-  factory Paragraph.fromRawEmbed(
-      {required Object data,
-      Map<String, dynamic>? attributes,
-      Map<String, dynamic>? blockAttributes}) {
+  factory Paragraph.fromRawEmbed({
+    required Object data,
+    Map<String, dynamic>? attributes,
+    Map<String, dynamic>? blockAttributes,
+    String? id,
+  }) {
     return Paragraph(
+      id: id,
       lines: <Line>[
         Line.fromData(data: data, attributes: attributes),
       ],
@@ -130,8 +152,9 @@ class Paragraph {
   /// This factory method creates a paragraph with a single line from the provided embed operation.
   ///
   /// [operation] is the Quill Delta operation representing the embed.
-  factory Paragraph.fromEmbed(fq.Operation operation) {
+  factory Paragraph.fromEmbed(fq.Operation operation, {String? id}) {
     return Paragraph(
+      id: id,
       lines: <Line>[
         Line.fromData(data: operation.data!, attributes: operation.attributes),
       ],
@@ -140,23 +163,86 @@ class Paragraph {
     )..seal();
   }
 
+  /// Get all the Lines into this Paragraph
   List<Line> get lines => List<Line>.unmodifiable(_lines);
+
+  /// Get all direct instances of the lines into this Paragraph
+  ///
+  /// This is called `unsafeLines` because this ones can be modified
+  /// but, all the changes won't be notified to this Paragraph
+  List<Line> unsafeLines() => [..._lines];
+
+  /// Get the last element of this Paragraph
   Line? get last => _lines.lastOrNull;
+
+  /// Get the first element of this Paragraph
   Line? get first => _lines.firstOrNull;
+
+  /// Get the length of lines
   int get length => _lines.length;
   bool get isEmpty => _lines.isEmpty;
   bool get isNotEmpty => !isEmpty;
+
+  /// Determines if this Paragraph is a block type one
   bool get isBlock => type == ParagraphType.block && blockAttributes != null;
+
+  /// Determines if this Paragraph is an embed type one
   bool get isEmbed =>
       type == ParagraphType.embed && lines.first.isEmbedFragment;
+
+  /// Determines if this Paragraph is a new line type one
   bool get isNewLine => type == ParagraphType.lineBreak && length == 1
       ? _lines.single.isNewLine
       : false;
+
+  /// Determines if this Paragraph is just a paragraph empty with a new line
+  /// that has block attributes
   bool get isNewLineWithBlockAttributes => isNewLine && blockAttributes != null;
   @Deprecated('Use isTextInsert')
   bool get isInsertText => type == ParagraphType.inline;
+
+  /// Determines if this Paragraph is just an inline type one
   bool get isTextInsert => type == ParagraphType.inline;
+
+  /// Determines if this paragraph cannot be modified
   bool get isSealed => _sealed;
+
+  /// Determines whether the last line is empty (just a newline) and whether the next
+  /// content should start in a new paragraph.
+  ///
+  /// This is typically used to decide whether to create a new paragraph containing
+  /// just a newline. For example:
+  ///
+  /// Given this Delta input:
+  /// ```json
+  /// [
+  ///   {"insert": "my_delta\n\n"}
+  /// ]
+  /// ```
+  ///
+  /// The parsed `Document` structure should be:
+  /// ```dart
+  /// Document:
+  ///   Paragraph:
+  ///     Line: [
+  ///       TextFragment: "my_delta"
+  ///     ]
+  ///     Type: inline
+  ///   Paragraph:
+  ///     Line: [
+  ///       TextFragment: "\n"
+  ///     ]
+  ///     Type: lineBreak
+  /// ```
+  ///
+  /// The first newline character serves as a separator between content, while the second
+  /// newline indicates an intentional line break. To maintain this distinction in the
+  /// object structure:
+  /// 1. The first newline is treated as content separation
+  /// 2. Subsequent newlines trigger the creation of a new paragraph
+  ///
+  /// This ensures proper semantic representation of intentional line breaks while
+  /// avoiding unnecessary paragraph divisions for content separators.
   bool get shouldBreakToNext => isEmpty ? false : last!.isEmpty;
   bool containsSameAttributes(Map<String, dynamic>? attrs) {
     return mapEquality(blockAttributes, attrs);
@@ -166,13 +252,18 @@ class Paragraph {
     _sealed = true;
     if (sealLines) {
       for (final Line line in _lines) {
-        line.seal();
+        if (!line.isSealed) line.seal();
       }
     }
   }
 
-  void unseal() {
+  void unseal({bool unsealLines = false}) {
     _sealed = false;
+    if (unsealLines) {
+      for (final Line line in _lines) {
+        if (line.isSealed) line.unseal();
+      }
+    }
   }
 
   void insertEmptyLine() {
@@ -286,7 +377,18 @@ class Paragraph {
   /// Creates a clone of the current paragraph.
   Paragraph get clone {
     return Paragraph(
+      id: id,
       lines: [..._lines],
+      blockAttributes: blockAttributes == null ? null : {...blockAttributes!},
+      type: type,
+    );
+  }
+
+  /// Creates a clone of the current paragraph.
+  Paragraph get deepClone {
+    return Paragraph(
+      id: id,
+      lines: _lines.map<Line>((Line l) => l.deepClone).toList(),
       blockAttributes: blockAttributes == null ? null : {...blockAttributes!},
       type: type,
     );

--- a/lib/flutter_quill_delta_easy_parser.dart
+++ b/lib/flutter_quill_delta_easy_parser.dart
@@ -11,3 +11,4 @@ export 'package:flutter_quill_delta_easy_parser/easy_parser/block_merger_builder
 export 'package:flutter_quill_delta_easy_parser/easy_parser/common_merger_builder.dart';
 export 'package:flutter_quill_delta_easy_parser/easy_parser/no_merger_builder.dart';
 export 'package:flutter_quill_delta_easy_parser/enums/enums.dart';
+export 'package:flutter_quill_delta_easy_parser/utils/nano_id_generator.dart';

--- a/lib/utils/nano_id_generator.dart
+++ b/lib/utils/nano_id_generator.dart
@@ -3,6 +3,10 @@ import 'dart:math';
 const String _hexDigits = '0123456789ABCDEF';
 
 String nanoid(int length) {
+  if (length <= 0 || length > 35) {
+    throw Exception(
+        "The length provided: $length, cannot be used to generate an id");
+  }
   final Random random = Random.secure();
   final StringBuffer buffer = StringBuffer();
 

--- a/test/flutter_quill_delta_easy_parser_test.dart
+++ b/test/flutter_quill_delta_easy_parser_test.dart
@@ -3,6 +3,22 @@ import 'package:flutter_quill_delta_easy_parser/flutter_quill_delta_easy_parser.
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('Should split newlines in two different Paragraphs', () {
+    final Delta delta = Delta()
+      ..insert("my_delta\n")
+      ..insert('\n');
+
+    final Document expectedDocument = Document(
+      paragraphs: [
+        Paragraph.fragment(TextFragment(data: "my_delta")),
+        Paragraph.newLine(),
+      ],
+    );
+
+    final Document? parsedDocument = DocumentParser().parseDelta(delta: delta);
+    _execExpects(parsedDocument, expectedDocument);
+  });
+
   test('Should convert image to paragraph embed', () {
     final Delta delta = Delta()
       ..insert({'image': '/device/user/to/path/file.jpg'})


### PR DESCRIPTION
## Description

Added new property for `Paragraph` and `Line` classes to assign a custom id. 

### Unrelated additions

* Some documentation for common methods in `Paragraph` class.
* `deepClone` getter to build a full clone of every element into `Paragraph` and `Line` classes.