### PR TITLE
Fix: data loss when parsing Delta to Document

### DIFF
--- a/lib/core/blocks/document.dart
+++ b/lib/core/blocks/document.dart
@@ -18,23 +18,33 @@ class Document {
   void insert(Paragraph paragraph) {
     final Paragraph? lastParagraph = paragraphs.lastOrNull;
     if (lastParagraph != null) {
-      if (lastParagraph.isEmpty || (lastParagraph.last?.isEmpty ?? false)) {
-        if (lastParagraph.isSealed) {
-          lastParagraph.unseal();
+      void replacePr(Paragraph from, Paragraph withThis) {
+        from.insertAll(withThis.lines);
+        from.setType(withThis.type);
+        from.blockAttributes = withThis.blockAttributes;
+        if ((from.isBlock || from.isEmbed || from.isNewLine) &&
+            !from.isSealed) {
+          from.seal(sealLines: true);
         }
-        lastParagraph.insertAll(paragraph.lines);
-        lastParagraph.setType(paragraph.type);
-        lastParagraph.blockAttributes = lastParagraph.blockAttributes;
-        if ((lastParagraph.isBlock ||
-                lastParagraph.isEmbed ||
-                lastParagraph.isNewLine) &&
-            !lastParagraph.isSealed) {
-          lastParagraph.seal(sealLines: true);
-        }
-        updateLast(paragraph);
+      }
+
+      if (lastParagraph.shouldBreakToNext && paragraph.isEmbed ||
+          paragraph.isNewLine) {
+        lastParagraph.unseal();
+        lastParagraph
+          ..removeLastLineIfNeeded()
+          ..seal();
+        updateLast(lastParagraph);
+      }
+
+      if (lastParagraph.isEmpty) {
+        lastParagraph.unseal();
+        replacePr(lastParagraph, paragraph);
+        updateLast(lastParagraph);
         return;
       }
     }
+
     paragraphs.add(paragraph);
   }
 

--- a/lib/core/blocks/document.dart
+++ b/lib/core/blocks/document.dart
@@ -18,8 +18,7 @@ class Document {
   void insert(Paragraph paragraph) {
     final Paragraph? lastParagraph = paragraphs.lastOrNull;
     if (lastParagraph != null) {
-      if (lastParagraph.shouldBreakToNext && paragraph.isEmbed ||
-          paragraph.isNewLine) {
+      if (lastParagraph.shouldBreakToNext) {
         lastParagraph.unseal();
         lastParagraph
           ..removeLastLineIfNeeded()

--- a/lib/core/blocks/document.dart
+++ b/lib/core/blocks/document.dart
@@ -18,16 +18,6 @@ class Document {
   void insert(Paragraph paragraph) {
     final Paragraph? lastParagraph = paragraphs.lastOrNull;
     if (lastParagraph != null) {
-      void replacePr(Paragraph from, Paragraph withThis) {
-        from.insertAll(withThis.lines);
-        from.setType(withThis.type);
-        from.blockAttributes = withThis.blockAttributes;
-        if ((from.isBlock || from.isEmbed || from.isNewLine) &&
-            !from.isSealed) {
-          from.seal(sealLines: true);
-        }
-      }
-
       if (lastParagraph.shouldBreakToNext && paragraph.isEmbed ||
           paragraph.isNewLine) {
         lastParagraph.unseal();
@@ -39,7 +29,15 @@ class Document {
 
       if (lastParagraph.isEmpty) {
         lastParagraph.unseal();
-        replacePr(lastParagraph, paragraph);
+        lastParagraph.insertAll(paragraph.lines);
+        lastParagraph.setType(paragraph.type);
+        lastParagraph.blockAttributes = paragraph.blockAttributes;
+        if ((lastParagraph.isBlock ||
+                lastParagraph.isEmbed ||
+                lastParagraph.isNewLine) &&
+            !lastParagraph.isSealed) {
+          lastParagraph.seal(sealLines: true);
+        }
         updateLast(lastParagraph);
         return;
       }

--- a/lib/core/blocks/paragraph.dart
+++ b/lib/core/blocks/paragraph.dart
@@ -61,7 +61,7 @@ class Paragraph {
     String? id,
   })  : _lines = List<Line>.from(lines),
         id = id == null || id.trim().isEmpty ? nanoid(8) : id,
-        _sealed = type == ParagraphType.block
+        _sealed = type == ParagraphType.block || type == ParagraphType.embed
             ? true
             : lines.isNotEmpty && lines.length == 1 && lines.first.isNotEmpty
                 ? lines.first.length > 1
@@ -80,22 +80,37 @@ class Paragraph {
         _sealed = true;
 
   @visibleForTesting
-  factory Paragraph.fragment(TextFragment frag, {String? id}) {
+  factory Paragraph.fragment(
+    TextFragment frag, {
+    String? id,
+    Map<String, dynamic>? blockAttributes,
+  }) {
     return Paragraph.sealed(
       id: id,
       lines: <Line>[
         Line(fragments: <TextFragment>[frag.clone])
       ],
-      type: ParagraphType.inline,
+      type: frag.data is! String
+          ? ParagraphType.embed
+          : frag.data == '\n'
+              ? ParagraphType.lineBreak
+              : blockAttributes != null
+                  ? ParagraphType.block
+                  : ParagraphType.inline,
+      blockAttributes:
+          blockAttributes?.isNotEmpty ?? false ? blockAttributes : null,
     );
   }
 
-  factory Paragraph.withLine({String? id}) {
+  factory Paragraph.withLine({
+    String? id,
+    Iterable<TextFragment>? fragments,
+  }) {
     return Paragraph(
       id: id,
       lines: <Line>[
         Line(
-          fragments: [],
+          fragments: [...?fragments],
         ),
       ],
       type: ParagraphType.inline,
@@ -114,14 +129,14 @@ class Paragraph {
     Map<String, dynamic>? blockAttributes,
     String? id,
   }) {
-    return Paragraph(
+    return Paragraph.sealed(
       id: id,
       lines: <Line>[
         Line.newLine(),
       ],
       blockAttributes: blockAttributes,
       type: ParagraphType.lineBreak,
-    )..seal();
+    );
   }
 
   /// Constructs a [Paragraph] instance from a Object embed.
@@ -132,7 +147,7 @@ class Paragraph {
     Map<String, dynamic>? blockAttributes,
     String? id,
   }) {
-    return Paragraph(
+    return Paragraph.sealed(
       id: id,
       lines: <Line>[
         Line.fromData(data: data, attributes: attributes),
@@ -143,7 +158,7 @@ class Paragraph {
               ? ParagraphType.block
               : ParagraphType.inline
           : ParagraphType.embed,
-    )..seal();
+    );
   }
 
   /// Constructs a [Paragraph] instance from a Quill Delta embed operation.
@@ -151,15 +166,23 @@ class Paragraph {
   /// This factory method creates a paragraph with a single line from the provided embed operation.
   ///
   /// [operation] is the Quill Delta operation representing the embed.
-  factory Paragraph.fromEmbed(fq.Operation operation, {String? id}) {
-    return Paragraph(
+  factory Paragraph.fromEmbed(
+    fq.Operation operation, {
+    String? id,
+    Map<String, dynamic>? blockAttributes,
+  }) {
+    final bool isInlineOp = operation.data is String;
+    return Paragraph.sealed(
       id: id,
       lines: <Line>[
-        Line.fromData(data: operation.data!, attributes: operation.attributes),
+        Line.fromData(
+          data: operation.data!,
+          attributes: operation.attributes,
+        ),
       ],
-      type:
-          operation.data is String ? ParagraphType.inline : ParagraphType.embed,
-    )..seal();
+      blockAttributes: blockAttributes,
+      type: isInlineOp ? ParagraphType.inline : ParagraphType.embed,
+    );
   }
 
   /// Get all the Lines into this Paragraph

--- a/test/flutter_quill_delta_easy_parser_test.dart
+++ b/test/flutter_quill_delta_easy_parser_test.dart
@@ -3,14 +3,36 @@ import 'package:flutter_quill_delta_easy_parser/flutter_quill_delta_easy_parser.
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('Ensure that is fixed: "Issue: Data Loss When Parsing Document #33"', () {
+    final Delta delta = Delta()
+      ..insert("My delta can innovate all of the existent editors\n")
+      ..insert({"img": "path"})
+      ..insert('\n\n\n');
+
+    final Document expectedDocument = Document(
+      paragraphs: [
+        Paragraph.fragment(TextFragment(data: "My delta can innovate all of the existent editors")),
+        Paragraph.fragment(TextFragment(
+          data: {"img": "path"},
+        )),
+        Paragraph.newLine(),
+        Paragraph.newLine(),
+        Paragraph.newLine(),
+      ],
+    );
+
+    final Document? parsedDocument = DocumentParser().parseDelta(delta: delta);
+    _execExpects(parsedDocument, expectedDocument);
+  });
+
   test('Should split newlines in two different Paragraphs', () {
     final Delta delta = Delta()
-      ..insert("my_delta\n")
+      ..insert("\n")
       ..insert('\n');
 
     final Document expectedDocument = Document(
       paragraphs: [
-        Paragraph.fragment(TextFragment(data: "my_delta")),
+        Paragraph.newLine(),
         Paragraph.newLine(),
       ],
     );
@@ -327,7 +349,7 @@ void _execExpects(Document? parsedDocument, Document expectedDocument) {
     expect(
       parsedDocument?.paragraphs[i].blockAttributes,
       expectedDocument.paragraphs[i].blockAttributes,
-      reason: 'Block difference at paragraph(index: $i).\n'
+      reason: 'Block difference at paragraph(index: [$i]).\n'
           'Parsed: ${parsedDocument?.paragraphs[i].blockAttributes},\nExpected: ${expectedDocument.paragraphs[i].blockAttributes}',
     );
     expect(


### PR DESCRIPTION
## Description

The `insert` method in the `Document` class fails to properly handle transitions between paragraphs, leading to unintended data loss—specifically, content before the first newline is discarded.  

The original implementation relies on an outdated API behavior, where it only checks if the last paragraph is empty or ends with an empty line before merging content. This logic is insufficient, as it doesn't account for cases where a paragraph break should be enforced (e.g., when `shouldBreakToNext` is true).  

#### Problematic Code:  
```dart
if (lastParagraph != null) {
  if (lastParagraph.isEmpty || (lastParagraph.last?.isEmpty ?? false)) {
    if (lastParagraph.isSealed) {
      lastParagraph.unseal();
    }
    lastParagraph.insertAll(paragraph.lines);
    lastParagraph.setType(paragraph.type);
    lastParagraph.blockAttributes = lastParagraph.blockAttributes;
    if ((lastParagraph.isBlock ||
          lastParagraph.isEmbed ||
          lastParagraph.isNewLine) &&
         !lastParagraph.isSealed) {
      lastParagraph.seal(sealLines: true);
    }
    updateLast(paragraph);
    return;
  }
  paragraphs.add(paragraph);
}
```  
**Flaws:**  
- Does not respect paragraph-breaking conditions (`shouldBreakToNext`).  
- Incorrectly reuses `lastParagraph.blockAttributes` instead of the new paragraph's attributes.  
- May improperly merge content when it should start a new paragraph.  

#### Solution:  
The fix involves better utilization of the existing API with updated logic:  

1. **Check for required paragraph breaks** (`shouldBreakToNext`) before merging.  
2. **Properly handle empty paragraphs** by inserting new content correctly.  
3. **Ensure block attributes** are taken from the new paragraph, not the old one.  

```dart
if (lastParagraph != null) {
  if (lastParagraph.shouldBreakToNext) {
    lastParagraph.unseal();
    lastParagraph
      ..removeLastLineIfNeeded()
      ..seal();
    updateLast(lastParagraph);
  }

  if (lastParagraph.isEmpty) {
    lastParagraph.unseal();
    lastParagraph.insertAll(paragraph.lines);
    lastParagraph.setType(paragraph.type);
    lastParagraph.blockAttributes = paragraph.blockAttributes;
    if ((lastParagraph.isBlock ||
            lastParagraph.isEmbed ||
            lastParagraph.isNewLine) &&
        !lastParagraph.isSealed) {
      lastParagraph.seal(sealLines: true);
    }
    updateLast(lastParagraph);
    return;
  }
}

paragraphs.add(paragraph);
```  

## Related issues

* Fix: https://github.com/CatHood0/flutter_quill_to_pdf/issues/33

## Type change

- [ ] ✨ **Feature:** New functionality without breaking existing features.
- [x] 🛠️ **Bug fix:** Resolves an issue without altering current behavior.
- [x] 🧹 **Refactor:** Code reorganization, no behavior change.
- [ ] ❌ **Breaking:** Alters existing functionality and requires updates.
- [x] 🧪 **Tests:** New or modified tests
- [ ] 📝 **Documentation:** Updates or additions to documentation.
- [ ] 🗑️ **Chore:** Routine tasks, or maintenance.
- [ ] ✅ **Build configuration change:** Build/configuration changes.
